### PR TITLE
Fix regex and add TestRunner unit test

### DIFF
--- a/src/testing/test_runner.py
+++ b/src/testing/test_runner.py
@@ -181,7 +181,7 @@ class TestRunner:
                     try:
                         # Look for patterns like "collected 5 items"
                         import re
-                        collected_match = re.search(r"collected (\d+) item", process.stdout)
+                        collected_match = re.search(r"collected (\d+) items?", process.stdout)
                         passed_match = re.search(r"(\d+) passed", process.stdout)
                         skipped_match = re.search(r"(\d+) skipped", process.stdout)
 

--- a/tests/test_testing/__init__.py
+++ b/tests/test_testing/__init__.py
@@ -1,0 +1,3 @@
+"""
+Tests for the testing modules of the canCANary CAN-Bus Simulator.
+"""

--- a/tests/test_testing/test_test_runner.py
+++ b/tests/test_testing/test_test_runner.py
@@ -1,0 +1,31 @@
+"""
+Unit tests for the TestRunner class.
+"""
+
+import subprocess
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from canary.testing.test_runner import TestRunner
+
+
+@pytest.mark.unit
+def test_run_tests_parses_plural_items(disable_logging):
+    """Test that run_tests correctly parses plural 'items' output."""
+    runner = TestRunner(test_directory="tests")
+
+    sample_stdout = (
+        "============================= test session starts ==============================\n"
+        "collected 2 items\n\n"
+        "============================== 2 passed in 0.01s ==============================\n"
+    )
+    mock_process = MagicMock(returncode=0, stdout=sample_stdout, stderr="")
+
+    with patch.object(subprocess, "run", return_value=mock_process):
+        with patch("os.path.exists", return_value=False):
+            summary = runner.run_tests(test_paths=["dummy"])
+
+    assert summary.total_tests == 2
+    assert summary.passed == 2
+


### PR DESCRIPTION
## Summary
- adjust regex in `TestRunner` to match both `item` and `items`
- add new tests for the testing utilities
- verify parsing of plural `items` output

## Testing
- `python -m pytest tests/test_testing/test_test_runner.py -q` *(fails: No module named pytest)*